### PR TITLE
Make time args work

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ posts that you know have been edited on Tumblr, pass suitable options to
  * Python 3
  * `pytumblr`
  * `xapian`
+ * `dateparser`
  * `flask` and `flask-assets` (for the web interface)
  * `uwsgi` (for the web interface)
- * `lark` (for date parsing, NYI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 celery
 lark
 pytumblr
+dateparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 celery
 lark
 pytumblr
-xapian

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 celery
-lark
 pytumblr
 dateparser

--- a/src/xapblr/date_parser.py
+++ b/src/xapblr/date_parser.py
@@ -1,4 +1,5 @@
 import lark
+from datetime import datetime
 
 
 def parse_date(date_str):
@@ -6,4 +7,4 @@ def parse_date(date_str):
     # returns a unix timestamp
     # Example inputs:
     # yesterday, 2 hours ago, last wednesday, 5 days ago, 1659706622
-    raise NotImplementedError
+    return datetime.strptime(date_str, "%Y-%m-%d").timestamp()

--- a/src/xapblr/date_parser.py
+++ b/src/xapblr/date_parser.py
@@ -1,10 +1,13 @@
-import lark
-from datetime import datetime
-
+import dateparser
 
 def parse_date(date_str):
     # takes a human-readable datetime string as understood by notmuch and
     # returns a unix timestamp
     # Example inputs:
     # yesterday, 2 hours ago, last wednesday, 5 days ago, 1659706622
-    return datetime.strptime(date_str, "%Y-%m-%d").timestamp()
+    #
+    # note (nost) - dateparser works for most of the above but not "last wednesday"
+    # but it's quick and easy
+    dt = dateparser.parse(date_str)
+    if dt is not None:
+        return int(dt.timestamp())

--- a/src/xapblr/date_parser.py
+++ b/src/xapblr/date_parser.py
@@ -11,3 +11,5 @@ def parse_date(date_str):
     dt = dateparser.parse(date_str)
     if dt is not None:
         return int(dt.timestamp())
+    print(f"failed to parse date string: {date_str}")
+


### PR DESCRIPTION
Quick and dirty implementation for `parse_date` using [`dateparser`](https://dateparser.readthedocs.io/).  Won't handle everything described in the docstring, but better than nothing.

Casting to int is important, because otherwise we end up passing something like `?before=1685602800.0` to the API, which it will ignore.

---

Unrelatedly, removed `xapian` from `requirements.txt` since it's not a pip-installable package ([cf.](https://pip.pypa.io/en/stable/reference/requirements-file-format/)).

This way, during setup you can do `pip install -r requirements.txt` to get all the pip-installable dependencies, and then install other dependencies separately as needed.