### PR TITLE
Fix error when indexing long non-ASCII tags

### DIFF
--- a/src/xapblr/index.py
+++ b/src/xapblr/index.py
@@ -19,6 +19,7 @@ from .utils import (
     get_api_key,
     get_author,
     get_db,
+    encode_tag,
     format_timestamp,
     prefixes,
     value_slots,
@@ -90,11 +91,7 @@ def index_post(post, tg):
     index_content(post, tg)
 
     for t in post["tags"]:
-        # xapian will never put a space in a term but we can just urlencode
-        doc.add_term(
-            # take the first 245 bytes since that's the max xapian term length
-            (prefixes["tag"] + urlencode(t.lower()))[:245]
-        )
+        doc.add_term(encode_tag(t))
 
     doc.add_value(value_slots["timestamp"], sortable_serialise(post["timestamp"]))
     doc.set_data(dumps(post))

--- a/src/xapblr/index.py
+++ b/src/xapblr/index.py
@@ -91,7 +91,10 @@ def index_post(post, tg):
 
     for t in post["tags"]:
         # xapian will never put a space in a term but we can just urlencode
-        doc.add_term(prefixes["tag"] + urlencode(t.lower()))
+        doc.add_term(
+            # take the first 245 bytes since that's the max xapian term length
+            (prefixes["tag"] + urlencode(t.lower()))[:245]
+        )
 
     doc.add_value(value_slots["timestamp"], sortable_serialise(post["timestamp"]))
     doc.set_data(dumps(post))

--- a/src/xapblr/search.py
+++ b/src/xapblr/search.py
@@ -32,7 +32,10 @@ def search_command(args):
 
 class TagProcessor(FieldProcessor):
     def __call__(self, args):
-        return Query(prefixes["tag"] + urlencode(args.lower()))
+        return Query(
+            # take the first 245 bytes since that's the max xapian term length
+            (prefixes["tag"] + urlencode(args.lower()))[:245]
+        )
 
 
 class DateRangeProcessor(RangeProcessor):

--- a/src/xapblr/search.py
+++ b/src/xapblr/search.py
@@ -15,7 +15,7 @@ from urllib.parse import quote as urlencode
 
 from .date_parser import parse_date
 from .render import renderers
-from .utils import get_db, prefixes, value_slots
+from .utils import get_db, encode_tag, prefixes, value_slots
 
 
 def search_command(args):
@@ -32,10 +32,7 @@ def search_command(args):
 
 class TagProcessor(FieldProcessor):
     def __call__(self, args):
-        return Query(
-            # take the first 245 bytes since that's the max xapian term length
-            (prefixes["tag"] + urlencode(args.lower()))[:245]
-        )
+        return Query(encode_tag(args))
 
 
 class DateRangeProcessor(RangeProcessor):

--- a/src/xapblr/utils.py
+++ b/src/xapblr/utils.py
@@ -64,6 +64,12 @@ def get_author(post):
         return post["broken_blog_name"]
 
 
+def encode_tag(tag):
+    # xapian will never put a space in a term but we can just urlencode
+    # take the first 245 bytes since that's the max xapian term length
+    return (prefixes["tag"] + urlencode(tag.lower()))[:245]
+
+
 def fix_date_range(d):
     def _fix(m):
         return m[0].replace(" ", "_")


### PR DESCRIPTION
Fixes `xapian.InvalidArgumentError: Term too long (> 245)` when indexing long tags with non-ASCII characters, like the one on [this post](https://www.tumblr.com/birdblogwhichisforbirds/186969738587/ad%C3%A9lie-is-smol-but-feisty-has-our-lovely).